### PR TITLE
Fixed inserting of line breaks

### DIFF
--- a/lib/spreadsheet.js
+++ b/lib/spreadsheet.js
@@ -349,7 +349,8 @@ Spreadsheet.prototype.compile = function() {
         continue;
       else
         obj.val = _.escape(obj.val.toString());
-
+      
+      obj.val = obj.val.replace(/\n|\r/gi, "&#10;");
       strs.push(this.entryTemplate(obj));
     }
 


### PR DESCRIPTION
When inserting values like "LINE \n BREAK", the line break (\n) gets lost.

To fix this, the line break characters (\n \r) need to be replaced with "&#10;"
